### PR TITLE
Removing AFNetworking dependency

### DIFF
--- a/SPTestRailReporter.podspec
+++ b/SPTestRailReporter.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
     s.source_files  = "SPTestRailReporter"
     s.requires_arc = true
     s.dependency 'NSData+Base64', '1.0.0'
-    s.dependency 'AFNetworking', '2.5.4'
     s.dependency 'JSONModel', '1.2.0'
 
 end

--- a/SPTestRailReporter/SPTestRailReporter.h
+++ b/SPTestRailReporter/SPTestRailReporter.h
@@ -29,7 +29,6 @@
 
 
 #import <Foundation/Foundation.h>
-#import <AFNetworking/AFNetworking.h>
 #import "SPTestRailConfigurationBuilder.h"
 #import "SPTestRailProject.h"
 #import "SPTestRailSuite.h"


### PR DESCRIPTION
- Removed AFNetworking 2.5.4 framework dependency.
- Replaced functionality with native NSURLSession API.

Native NSURLSession provides neat API to make a request to the network. So, I think it would be nice to get rid of unnecessary third-party dependency.